### PR TITLE
Convert entity state reducers in example app to functions.

### DIFF
--- a/examples/application/state.md
+++ b/examples/application/state.md
@@ -37,7 +37,10 @@ import { createReducer } from '@ngrx/store';
 import { Customer } from 'models';
 
 export const { initialState: customerInitialState, facade: CustomerFacadeBase } = buildState(Customer);
-export const customerReducer = createReducer(customerInitialState);
+
+export function customerReducer(state = initialState): IEntityState<Customer> {
+  return state;
+}
 ```
 {% endcode-tabs-item %}
 
@@ -48,7 +51,11 @@ import { createReducer } from '@ngrx/store';
 import { Order } from 'models';
 
 export const { initialState: orderInitialState, facade: OrderFacadeBase } = buildState(Order);
-export const orderReducer = createReducer(initialState);
+
+export function orderReducer(state = initialState): IEntityState<Order> {
+  return state;
+}
+
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}


### PR DESCRIPTION
AOT compiling does not work properly when using createReducer for
an AE entity's reducer.  The examples in the From Scratch section
recognize this and export a reducer function.  However the code in
the example app uses `createReducer` which causes a build failure
if using AOT compiling.  This commit updates the example application
documents to match the From Scratch documents when creating reducers.