### PR TITLE
chore(quickstart): fix missing import and decorator

### DIFF
--- a/getting-started/quick-start.md
+++ b/getting-started/quick-start.md
@@ -46,8 +46,12 @@ Before you can actually create your state, you will need to create your entity m
 {% tabs %}
 {% tab title="models/customer.model.ts" %}
 ```typescript
-import { Key } from '@briebug/ngrx-auto-entity';
+import { Entity, Key } from '@briebug/ngrx-auto-entity';
 
+@Entity({
+  modelName: 'Customer',
+  uriName: 'customers'
+})
 export class Customer {
     @Key id: number;
     name: string;


### PR DESCRIPTION
There was a missing @Entity decorator and import from the Entity model example in the quickstart docs.
Copied the exact code from the more in-depth version so as to avoid confusion.
https://briebug.gitbook.io/ngrx-auto-entity/getting-started/from-scratch/entity-model